### PR TITLE
Fix order list route and unify GraphQL service

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Este projeto implementa um sistema de cadastro e listagem de pedidos (orders), u
 
 2.1 - **POST /order – Cria um pedido.**
 
-2.2 - **GET /order – Lista todos os pedidos.**
+2.2 - **GET /orders – Lista todos os pedidos.**
 
 4. **GraphQL Endpoint:**
 Query listOrders para listar pedidos.

--- a/api.http
+++ b/api.http
@@ -9,4 +9,4 @@ Content-Type: application/json
 }
 
 ### Listar Orders
-GET http://localhost:8080/order
+GET http://localhost:8080/orders

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -44,6 +44,13 @@ func main() {
 			http.Error(w, "Método não permitido", http.StatusMethodNotAllowed)
 		}
 	})
+	mux.HandleFunc("/orders", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Método não permitido", http.StatusMethodNotAllowed)
+			return
+		}
+		handleListOrders(w, r, orderService)
+	})
 
 	// Configura o endpoint GraphQL
 	schema := infrastructure.NewGraphQLSchema(db)

--- a/internal/infrastructure/graphql.go
+++ b/internal/infrastructure/graphql.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/graphql-go/graphql"
 	"github.com/willianfariabatista/my-challenge/internal/domain"
+	"github.com/willianfariabatista/my-challenge/internal/service"
 )
 
 func NewGraphQLSchema(db *sql.DB) graphql.Schema {
+	orderService := service.NewOrderService(db)
 	// Define o objeto GraphQL para Order
 	orderType := graphql.NewObject(graphql.ObjectConfig{
 		Name: "Order",
@@ -45,21 +47,7 @@ func NewGraphQLSchema(db *sql.DB) graphql.Schema {
 			"listOrders": &graphql.Field{
 				Type: graphql.NewList(orderType),
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
-					rows, err := db.Query("SELECT id, name, price, quantity, total, created_at, updated_at FROM orders")
-					if err != nil {
-						return nil, err
-					}
-					defer rows.Close()
-
-					var orders []domain.Order
-					for rows.Next() {
-						var o domain.Order
-						if err := rows.Scan(&o.ID, &o.Name, &o.Price, &o.Quantity, &o.Total, &o.CreatedAt, &o.UpdatedAt); err != nil {
-							return nil, err
-						}
-						orders = append(orders, o)
-					}
-					return orders, nil
+					return orderService.ListOrders(p.Context)
 				},
 			},
 		},


### PR DESCRIPTION
## Summary
- expose `/orders` HTTP endpoint for listing orders
- reuse OrderService inside GraphQL schema
- document updated route in README and api.http

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6849934d378483288b264d9801feff64